### PR TITLE
add exercise which uses the framework->query for arbitrary SQL execution

### DIFF
--- a/docs/guide_for_devs.md
+++ b/docs/guide_for_devs.md
@@ -374,7 +374,7 @@ The solutions provided below use both built-in module methods and the REDCap cla
 
 ### [Intro to Queries]({{ site.repo_root }}exercises/intro_to_queries/)
 
-In this module, you will complete a plugin page that allows admins to assign and revoke privileges for users in bulk. Make your changes in `ExternalModule.php`; you will need to write a few lines of SQL to make an `UPDATE` statement.
+In this module, you will complete a plugin page that allows admins to assign and revoke privileges for users in bulk. Make your changes in `ExternalModule.php`; you will need to write a few lines of SQL to make an `UPDATE` statement. If you visit the plugin page before you complete the `gatherUsers` function, you will receive a fatal error in `ExternalModule.php`. This error is normal. Work the problem.
 
 You will occasionally have to write SQL queries; most often, this need will arise when writing a module that adds a feature for REDCap admins. Writing your own SQL should be a last resort after you have considered all of your builtin options.
 

--- a/docs/guide_for_devs.md
+++ b/docs/guide_for_devs.md
@@ -374,16 +374,16 @@ The solutions provided below use both built-in module methods and the REDCap cla
 
 ### [Intro to Queries]({{ site.repo_root }}exercises/intro_to_queries/)
 
-In this module, you will complete a plugin page that allows admins to assign and revoke privileges for users in bulk. Your changes should be made in `ExternalModule.php`, you will need to write a few lines of SQL to make an `UPDATE` statement.
+In this module, you will complete a plugin page that allows admins to assign and revoke privileges for users in bulk. Make your changes in `ExternalModule.php`; you will need to write a few lines of SQL to make an `UPDATE` statement.
 
-You will occasionally have to write your own SQL queries, most often this need will arise when writing a quality-of-life module for admins. Writing your own SQL should be a last resort after you have considered all of your builtin options.
+You will occasionally have to write SQL queries; most often, this need will arise when writing a module that adds a feature for REDCap admins. Writing your own SQL should be a last resort after you have considered all of your builtin options.
 
-While evaluating builtin options for this exercise, you might consider using `framework->getUser`, but you want _all_ users -- and you don't want to have admins have to remember usernames.
-When a module call doesn't work, you should look at its source code to see if it calls a core class. `framework->getUser` is a wrapper around `\REDCap::getUsers()`, but calling this is _also_ unsuitable since it is only allowed in a project context, but we are building a plugin page for the Control Center.
+While evaluating builtin options for this exercise, you might be tempted to use `framework->getUser`. It won't meet your needs, but it's worth exploring why. For this module, you need a class method that lists _all_ users, but `framework->getUser` does not do that.
+When a module call doesn't work, look at its source code to see if it calls a core class. `framework->getUser` is a wrapper around `\REDCap::getUsers()` which might seem useful, but calling this is _also_ unsuitable since it is only allowed in a project context. As we are writing a plugin page for the Control Center, `\REDCap::getUsers()` will fail. The project context requirement in `\REDCap::getUsers()` forces us to write a SQL query of REDCap's user information table.
 
-You will probably find your [docker environment's phpmyadmin container](http://localhost/phpmyadmin) useful for this exercise.
+You will probably find your [docker environment's PHPMyAdmin container](http://localhost/phpmyadmin/) useful for this exercise. Adjust that URL to match the port number of your docker environment's web server container if it fails.
 
-**NB**: Those of you familiar with SQL may wonder about the use of prepared statements. These are _not_ currently implemented but will be in the near future - in Framework Version 4 - read the [official documentation on queries](https://github.com/vanderbilt/redcap-external-modules/blob/release/docs/querying.md) for more information. An example of using prepared statements is provided in the solution below. 
+**NB**: Those of you familiar with SQL may wonder about the use of prepared statements. These are _not_ currently implemented but will be soon - in Framework Version 4 - read the [official documentation on queries](https://github.com/vanderbilt/redcap-external-modules/blob/release/docs/querying.md) for more information. An example of using prepared statements is provided in the solution below.
 
 <details>
 <summary>Example Solution

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -40,3 +40,7 @@ Read the source code of the following files (relative to the root of your `redca
 - `Classes/`
     - `REDCap.php`
     - `Records.php`
+
+## Intro to Queries
+
+Read [the official documentation on module functions](https://github.com/vanderbilt/redcap-external-modules/blob/testing/docs/framework/intro.md). Search for the `query` function.

--- a/exercises/intro_to_queries/ExternalModule.php
+++ b/exercises/intro_to_queries/ExternalModule.php
@@ -17,9 +17,6 @@ class ExternalModule extends AbstractExternalModule {
             'ajaxpage' => $this->framework->getUrl('pages/ajaxpage.php')
         ];
         $this->setJsSettings($settings);
-
-        //$result = $this->alterUser(['bob', 'carol', 'dan'], 1);
-        //SQL injection
     }
 
     protected function includeJs($path) {

--- a/exercises/intro_to_queries/ExternalModule.php
+++ b/exercises/intro_to_queries/ExternalModule.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace IntroQueries\ExternalModule;
+
+use ExternalModules\AbstractExternalModule;
+
+class ExternalModule extends AbstractExternalModule {
+
+    function buildPluginPage() {
+        // Load in resources for Select2
+        $this->includeJsResource('select2.js');
+        $this->includeCssResource('select2.css');
+
+        $this->includeJs('js/iq.js');
+        $settings = [
+            'users' => $this->gatherUsers(),
+            'ajaxpage' => $this->framework->getUrl('pages/ajaxpage.php')
+        ];
+        $this->setJsSettings($settings);
+
+        //$result = $this->alterUser(['bob', 'carol', 'dan'], 1);
+        //SQL injection
+    }
+
+    protected function includeJs($path) {
+        echo '<script src="' . $this->framework->getUrl($path, true) . '">;</script>';
+    }
+
+    protected function includeJsResource($library) {
+        echo '<script src="' . APP_PATH_JS . $library . '">;</script>';
+    }
+
+    protected function includeCssResource($library) {
+        echo '<link href="' . APP_PATH_CSS . $library . '" rel="stylesheet" />';
+    }
+
+    protected function setJsSettings($settings) {
+        echo '<script>introQueries = ' . json_encode($settings) . ';</script>';
+    }
+
+    function gatherUsers() {
+        // FIXME: use $sql with an appropriate function to get a list of every user
+
+        $sql = 'SELECT username
+            FROM redcap_user_information';
+
+        /* stop writing here */
+        // parse the mysqli response object into an array
+        $username_array = array_column(
+                $result->fetch_all(MYSQLI_ASSOC),
+                'username'
+                );
+        return $username_array;
+    }
+
+    function alterUsers($users, $new_value) {
+        $users = implode('", "', $users);
+        // FIXME: write and run the SQL command, log what was done
+
+        return $result;
+    }
+
+}

--- a/exercises/intro_to_queries/README.md
+++ b/exercises/intro_to_queries/README.md
@@ -1,0 +1,12 @@
+# Intro to Queries
+
+Provides a page in the control center allowing admins to alter users' privileges to create databases at once.
+
+## Prerequisites
+- REDCap >= 8.0.3 (for versions < 8.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
+
+## Installation
+- Clone this repo into to `<redcap-root>/modules/intro_queries_v0.0.0`.
+- Go to **Control Center > Manage External Modules** and enable **Intro to Queries**.
+- For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable **Intro to Queries** for that project.
+

--- a/exercises/intro_to_queries/config.json
+++ b/exercises/intro_to_queries/config.json
@@ -1,0 +1,22 @@
+{
+    "name": "Intro to Queries",
+    "description": "Revoke or allow user privileges in bulk",
+    "namespace": "IntroQueries\\ExternalModule",
+    "framework-version": 3,
+    "authors": [
+        {
+            "name": "Kyle Chesney",
+            "email": "kyle.chesney@ufl.edu",
+            "institution": "University of Florida - CTSI"
+        }
+    ],
+   "links": {
+      "control-center": [
+         {
+            "name": "Page",
+            "icon": "fas fa-globe",
+            "url": "pages/user_selection.php"
+         }
+      ]
+   }
+}

--- a/exercises/intro_to_queries/js/iq.js
+++ b/exercises/intro_to_queries/js/iq.js
@@ -1,0 +1,26 @@
+$( document ).ready(function() {
+    $('#users').select2({
+        width: '25%',
+        data: introQueries.users
+    });
+
+    $('#submit').click(function() {
+        let formData = new FormData($('form')[0]);
+        $.ajax(
+            {
+                url: introQueries.ajaxpage,
+                type: 'POST',
+                processData: false,
+                contentType: false,
+                something: 'true',
+                data: formData,
+                success: function(pageData, textStatus, jqXHR) {
+                    alert(pageData);
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    alert('an error occured');
+                    console.log(errorThrown);
+                }
+            });
+    });
+});

--- a/exercises/intro_to_queries/pages/ajaxpage.php
+++ b/exercises/intro_to_queries/pages/ajaxpage.php
@@ -1,0 +1,8 @@
+<?php
+
+extract($_POST);
+if ($module->alterUsers($users, $newValue)) {
+    echo "Set allow_create_db to $newValue for " . implode(', ', $users);
+} else {
+    echo 'something went wrong';
+}

--- a/exercises/intro_to_queries/pages/plugin_page.html
+++ b/exercises/intro_to_queries/pages/plugin_page.html
@@ -1,0 +1,31 @@
+<form action="javascript:void(0)" method="get">
+<label for="users">
+    Select users
+</label>
+<select id="users" name="users[]" multiple="multiple">
+    <!--
+    <option value="admin">admin</option>
+    <option value="alice">alice</option>
+    <option value="bob">bob</option>
+    <option value="carol">carol</option>
+    <option value="dan">dan</option>
+    -->
+</select>
+
+<br />
+
+<label for="newValue">
+    Allow user(s) to create databases?
+</label>
+<br />
+
+<input type="radio" name="newValue" id="Disable" value="0">
+<label for="Disable">Disable</label>
+<br />
+<input type="radio" name="newValue" id="Allow" value="1">
+<label for="Allow">Allow</label>
+
+<br />
+
+<input type="submit" id="submit">
+</form>

--- a/exercises/intro_to_queries/pages/user_selection.php
+++ b/exercises/intro_to_queries/pages/user_selection.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once APP_PATH_DOCROOT . 'ControlCenter/header.php';
+
+$module->buildPluginPage();
+include 'plugin_page.html';
+
+require_once APP_PATH_DOCROOT . 'ControlCenter/footer.php';


### PR DESCRIPTION
While working on this PR, I realized that all reference to the official documentation refer to the default branch, `testing`. It may be harmless in most cases, but in this exercise it shows a feature that does not exist for an essential framework method. I will make another commit changing these to reference `release`.