### PR TITLE
Use `docker compose` instead of `docker-compose`

### DIFF
--- a/docs/emd101.md
+++ b/docs/emd101.md
@@ -43,7 +43,7 @@ These tools are recommended for those with no experience in software development
 
 ![VSCodium select .env file](/assets/img/vscodium_3.png#screenshot)
 
-- Paste this block at the end of the file and save it. Make changes to reflect your timezone and REDCap version number. You can find a list of valid time zones at [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)  
+- Paste this block at the end of the file and save it. Make changes to reflect your timezone and REDCap version number. You can find a list of valid time zones at [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 The port numbers should reflect your REDCap version number in some way so you can keep your different REDCap installations from colliding and tell them apart. Each of these port numbers needs to be unique. The standard used here compresses the REDCap version number into 4 digits and prefixes it with 1 through 4. For example, 10.3.3 becomes 1033. With prefixes, that becomes 11033, 21033, 31033, and 41033. Any method that makes unique port numbers and works for you is fine, though be aware that the max allowed port number is 65535.
 ```
 TZ=America/Chicago
@@ -60,7 +60,7 @@ You'll need a terminal that's in the `redcap-docker-compose` directory to start 
 - If you did not use VSCode, open a terminal or git-bash session and cd to the `redcap-docker-compose` directory
     - GitHub Desktop can open a terminal cd'd to the `redcap-docker-compose` folder with the shortcut \<ctrl\>\`
 - Change directories into the `rdc` folder with the command `cd rdc`
-- In the terminal start the containers with this command `docker-compose up -d`
+- In the terminal start the containers with this command `docker compose up -d`
 
 ![terminal nav and docker-compose up -d](/assets/img/terminal-dcup.png#screenshot)
 
@@ -98,10 +98,10 @@ rm -rf logs
 cd rdc
 
 # Destroy the containers and their volumes
-docker-compose down -v
+docker compose down -v
 
 # Rebuild the containers and volumes from scratch
-docker-compose up -d
+docker compose up -d
 ```
 
 If it fails again, you'll need to dig deeper to find out why. It's probably just a small thing, but knowing which small thing is hard to anticipate. Sorry about that.


### PR DESCRIPTION
Use `docker compose` instead of `docker-compose` to use Docker Compose v2, following commits in 123andy/redcap-docker-compose

Addresses issue #47